### PR TITLE
Implement Single & Allow Injecting Coroutine Dispatcher 

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="FrameworkDetectionExcludesConfiguration">

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = "gg.ingot.iron"
-version = "1.0.0"
+version = "1.0.1"
 
 repositories {
     mavenCentral()
@@ -15,6 +15,7 @@ dependencies {
 
     // unit tests
     testImplementation(kotlin("test"))
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0-RC")
     testImplementation("org.xerial:sqlite-jdbc:3.46.0.0")
     testImplementation("ch.qos.logback:logback-classic:1.5.6")
 }

--- a/src/main/kotlin/gg/ingot/iron/Iron.kt
+++ b/src/main/kotlin/gg/ingot/iron/Iron.kt
@@ -18,7 +18,7 @@ import kotlin.reflect.KClass
 @Suppress("MemberVisibilityCanBePrivate")
 class Iron(
     private val connectionString: String,
-    private val defaultDispatcher: CoroutineDispatcher = Dispatchers.IO
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {
 
     private val logger = LoggerFactory.getLogger(Iron::class.java)
@@ -96,7 +96,7 @@ class Iron(
         val connection = connection
             ?: error("Connection is not open, call connect() before using the connection.")
 
-        return withContext(defaultDispatcher) {
+        return withContext(dispatcher) {
             connection.createStatement().executeQuery(query)
         }
     }
@@ -137,7 +137,7 @@ class Iron(
         val connection = connection
             ?: error("Connection is not open, call connect() before using the connection.")
 
-        return withContext(defaultDispatcher) {
+        return withContext(dispatcher) {
             connection.createStatement().execute(statement)
         }
     }
@@ -154,7 +154,7 @@ class Iron(
         val connection = connection
             ?: error("Connection is not open, call connect() before using the connection.")
 
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatcher) {
             val preparedStatement = connection.prepareStatement(statement)
 
             for ((index, value) in values.withIndex()) {

--- a/src/main/kotlin/gg/ingot/iron/Iron.kt
+++ b/src/main/kotlin/gg/ingot/iron/Iron.kt
@@ -2,8 +2,7 @@ package gg.ingot.iron
 
 import gg.ingot.iron.representation.DBMS
 import gg.ingot.iron.sql.MappedResultSet
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.*
 import org.intellij.lang.annotations.Language
 import org.slf4j.LoggerFactory
 import java.sql.Connection
@@ -18,7 +17,8 @@ import kotlin.reflect.KClass
  */
 @Suppress("MemberVisibilityCanBePrivate")
 class Iron(
-    private val connectionString: String
+    private val connectionString: String,
+    private val defaultDispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {
 
     private val logger = LoggerFactory.getLogger(Iron::class.java)
@@ -57,7 +57,7 @@ class Iron(
      */
     suspend fun <T: Any?> use(block: suspend (Connection) -> T): T {
         val connection = connection
-            ?: throw IllegalStateException("Connection is not open, call connect() before using the connection.")
+            ?: error("Connection is not open, call connect() before using the connection.")
 
         return block(connection)
     }
@@ -68,7 +68,7 @@ class Iron(
      */
     suspend fun <T: Any?> transaction(block: suspend Iron.() -> T): T {
         val connection = connection
-            ?: throw IllegalStateException("Connection is not open, call connect() before using the connection.")
+            ?: error("Connection is not open, call connect() before using the connection.")
 
         try {
             connection.autoCommit = false
@@ -86,6 +86,7 @@ class Iron(
 
     /**
      * Executes a raw query on the database and returns the result set.
+     *
      * **Note:** This method does no validation on the query, it is up to the user to ensure the query is safe.
      * @param query The query to execute on the database.
      * @return The result set from the query.
@@ -93,15 +94,16 @@ class Iron(
      */
     suspend fun query(@Language("SQL") query: String): ResultSet {
         val connection = connection
-            ?: throw IllegalStateException("Connection is not open, call connect() before using the connection.")
+            ?: error("Connection is not open, call connect() before using the connection.")
 
-        return withContext(Dispatchers.IO) {
+        return withContext(defaultDispatcher) {
             connection.createStatement().executeQuery(query)
         }
     }
 
     /**
      * Executes a raw query on the database and maps the result set to a model.
+     *
      * **Note:** This method does no validation on the query, it is up to the user to ensure the query is safe.
      * @param query The query to execute on the database.
      * @param clazz The class to map the result set to.
@@ -125,6 +127,7 @@ class Iron(
 
     /**
      * Executes a raw statement on the database.
+     *
      * **Note:** This method does no validation on the statement, it is up to the user to ensure the statement is safe.
      * @param statement The statement to execute on the database.
      * @return If the first result is a ResultSet object; false if it is an update count or there are no results
@@ -132,9 +135,9 @@ class Iron(
      */
     suspend fun execute(@Language("SQL") statement: String): Boolean {
         val connection = connection
-            ?: throw IllegalStateException("Connection is not open, call connect() before using the connection.")
+            ?: error("Connection is not open, call connect() before using the connection.")
 
-        return withContext(Dispatchers.IO) {
+        return withContext(defaultDispatcher) {
             connection.createStatement().execute(statement)
         }
     }
@@ -149,7 +152,7 @@ class Iron(
      */
     suspend fun prepare(@Language("SQL") statement: String, vararg values: Any): ResultSet? {
         val connection = connection
-            ?: throw IllegalStateException("Connection is not open, call connect() before using the connection.")
+            ?: error("Connection is not open, call connect() before using the connection.")
 
         return withContext(Dispatchers.IO) {
             val preparedStatement = connection.prepareStatement(statement)
@@ -176,7 +179,7 @@ class Iron(
      */
     suspend fun <T: Any> prepare(@Language("SQL") statement: String, clazz: KClass<T>, vararg values: Any): MappedResultSet<T> {
         val resultSet = prepare(statement, *values)
-            ?: throw IllegalStateException("No result set was returned from the prepared statement.")
+            ?: error("No result set was returned from the prepared statement.")
 
         return MappedResultSet(resultSet, clazz)
     }

--- a/src/main/kotlin/gg/ingot/iron/representation/DBMS.kt
+++ b/src/main/kotlin/gg/ingot/iron/representation/DBMS.kt
@@ -22,11 +22,14 @@ internal enum class DBMS(val value: String, val className: String) {
     INTERBASE("interbase", "interbase.interclient.Driver"),
     ;
 
+    /**
+     * Loads the driver for the DBMS, throwing an exception if the driver is not found.
+     */
     fun load() {
         try {
             Class.forName(className)
         } catch (e: ClassNotFoundException) {
-            throw IllegalStateException("Failed to load driver for DBMS $name, make sure the driver is on the classpath or added as a dependency.")
+            error("Failed to load driver for DBMS $name, make sure the driver is on the classpath or added as a dependency.")
         }
     }
 

--- a/src/main/kotlin/gg/ingot/iron/sql/MappedResultSet.kt
+++ b/src/main/kotlin/gg/ingot/iron/sql/MappedResultSet.kt
@@ -41,6 +41,29 @@ class MappedResultSet<T: Any> internal constructor(
     }
 
     /**
+     * Gets the model from the result set at its current row.
+     * @return The model from the result set.
+     * @since 1.1
+     */
+    fun single(): T {
+        return singleNullable() ?: error("Expected a single result, but found none.")
+    }
+
+    /**
+     * Gets the model from the result set at its current row.
+     * @return The model from the result set or null if the result set is empty.
+     * @since 1.1
+     */
+    fun singleNullable(): T? {
+        val value = getNext()
+        if (next()) {
+            error("Expected a single or no result, but found more than one")
+        }
+
+        return value
+    }
+
+    /**
      * Get all the models from the result set.
      * @return A list of the mapped models.
      * @since 1.0

--- a/src/main/kotlin/gg/ingot/iron/transformer/ModelTransformer.kt
+++ b/src/main/kotlin/gg/ingot/iron/transformer/ModelTransformer.kt
@@ -15,7 +15,11 @@ import kotlin.reflect.jvm.javaField
  * @since 1.0
  */
 internal object ModelTransformer {
-
+    /**
+     * Transforms a class into an entity model, which holds information about the class model.
+     * @param clazz The class to transform into an entity model.
+     * @return The entity model representation of the class.
+     */
     fun transform(clazz: KClass<*>): EntityModel {
         return ModelRepository.models.getOrPut(clazz) {
             val fields = mutableListOf<EntityField>()
@@ -29,7 +33,7 @@ internal object ModelTransformer {
 
                 fields.add(EntityField(
                     field,
-                    field.javaField ?: throw IllegalStateException("Field ${field.name} has no backing field."),
+                    field.javaField ?: error("Field ${field.name} has no backing field."),
                     annotation?.name ?: field.name,
                     field.returnType.isMarkedNullable
                 ))

--- a/src/main/kotlin/gg/ingot/iron/transformer/ResultTransformer.kt
+++ b/src/main/kotlin/gg/ingot/iron/transformer/ResultTransformer.kt
@@ -27,7 +27,7 @@ object ResultTransformer {
             for (field in entity.fields) {
                 val value = result.getObject(field.columnName) ?: null
                 if (value == null && !field.nullable) {
-                    throw IllegalStateException("Field '${field.field.name}' is not nullable but the associated column '${field.columnName}' was null for model: $clazz")
+                    error("Field '${field.field.name}' is not nullable but the associated column '${field.columnName}' was null for model: $clazz")
                 }
 
                 field.javaField.setAccessible(true)
@@ -42,7 +42,7 @@ object ResultTransformer {
                 val value = result.getObject(field.columnName) ?: null
 
                 if (value == null && !field.nullable) {
-                    throw IllegalStateException("Field '${field.field.name}' is not nullable but the associated column '${field.columnName}' was null for model: $clazz")
+                    error("Field '${field.field.name}' is not nullable but the associated column '${field.columnName}' was null for model: $clazz")
                 }
 
                 value
@@ -50,7 +50,7 @@ object ResultTransformer {
 
             return fullConstructor.call(*fields.toTypedArray())
         } else {
-            throw IllegalStateException("No empty or full constructor found for model: $clazz")
+            error("No empty or full constructor found for model: $clazz")
         }
     }
 


### PR DESCRIPTION
Allow for consumers to inject their own Coroutine Dispatcher to Iron and add new utilities for retrieving only a single result from `MappedResultSet`.