### PR TITLE
Implement Custom Column Deserialization Strategies

### DIFF
--- a/src/main/kotlin/gg/ingot/iron/annotations/Column.kt
+++ b/src/main/kotlin/gg/ingot/iron/annotations/Column.kt
@@ -1,9 +1,14 @@
 package gg.ingot.iron.annotations
 
+import gg.ingot.iron.serialization.ColumnDeserializer
+import gg.ingot.iron.serialization.EmptyDeserializer
+import kotlin.reflect.KClass
+
 @Target(AnnotationTarget.PROPERTY)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class Column(
     val name: String = "",
     val ignore: Boolean = false,
-    val json: Boolean = false
+    val json: Boolean = false,
+    val deserializer: KClass<out ColumnDeserializer<*, *>> = EmptyDeserializer::class
 )

--- a/src/main/kotlin/gg/ingot/iron/representation/EntityField.kt
+++ b/src/main/kotlin/gg/ingot/iron/representation/EntityField.kt
@@ -1,5 +1,6 @@
 package gg.ingot.iron.representation
 
+import gg.ingot.iron.serialization.ColumnDeserializer
 import java.lang.reflect.Field
 import kotlin.reflect.KProperty
 
@@ -14,5 +15,6 @@ internal data class EntityField(
     val javaField: Field,
     val columnName: String,
     val nullable: Boolean,
-    val isJson: Boolean
+    val isJson: Boolean,
+    val deserializer: ColumnDeserializer<*, *>?
 )

--- a/src/main/kotlin/gg/ingot/iron/serialization/ColumnDeserializer.kt
+++ b/src/main/kotlin/gg/ingot/iron/serialization/ColumnDeserializer.kt
@@ -1,0 +1,22 @@
+package gg.ingot.iron.serialization
+
+/**
+ * Adapt column fields to a provided type.
+ * @param From The type to adapt from.
+ * @param To The type to adapt to.
+ * @author DebitCardz
+ * @since 1.3
+ */
+interface ColumnDeserializer <From, To> {
+    /**
+     * Deserialize the given value into the provided type.
+     * @param value The value to deserialize.
+     * @return The deserialized value.
+     */
+    fun deserialize(value: From): To
+}
+
+// Internally used to denote that a column should not be deserialized.
+internal object EmptyDeserializer : ColumnDeserializer<Nothing, Nothing> {
+    override fun deserialize(value: Nothing): Nothing = error("This deserializer should not be used")
+}

--- a/src/main/kotlin/gg/ingot/iron/transformer/ModelTransformer.kt
+++ b/src/main/kotlin/gg/ingot/iron/transformer/ModelTransformer.kt
@@ -7,6 +7,7 @@ import gg.ingot.iron.representation.EntityModel
 import gg.ingot.iron.serialization.ColumnDeserializer
 import gg.ingot.iron.serialization.EmptyDeserializer
 import kotlin.reflect.KClass
+import kotlin.reflect.KProperty
 import kotlin.reflect.KProperty1
 import kotlin.reflect.full.createInstance
 import kotlin.reflect.full.declaredMemberProperties
@@ -56,7 +57,7 @@ internal object ModelTransformer {
      * @return The name for the field.
      */
     private fun retrieveName(
-        field: KProperty1<out Any, *>,
+        field: KProperty<*>,
         annotation: Column?
     ): String {
         // defaults to "" if column is added but no name is provided

--- a/src/test/kotlin/DatabaseTest.kt
+++ b/src/test/kotlin/DatabaseTest.kt
@@ -3,6 +3,7 @@ import com.google.gson.Gson
 import gg.ingot.iron.Iron
 import gg.ingot.iron.IronSettings
 import gg.ingot.iron.annotations.Column
+import gg.ingot.iron.serialization.ColumnDeserializer
 import gg.ingot.iron.serialization.SerializationAdapter
 import java.sql.SQLException
 import kotlin.test.Test
@@ -147,58 +148,5 @@ class DatabaseTest {
         } catch (ex: Exception) {
             assert(ex is IllegalStateException)
         }
-    }
-
-    @Test
-    fun `gson obj deserialization`() = runTest {
-        val ironSerializationInstance = Iron(
-            "jdbc:sqlite::memory:",
-            IronSettings(
-                serialization = SerializationAdapter.Gson(Gson())
-            )
-        ).connect()
-
-        data class EmbeddedJson(val test: String)
-        data class ExampleResponse(
-            @Column(json = true)
-            val test: EmbeddedJson
-        )
-
-        val res = ironSerializationInstance.transaction {
-            execute("CREATE TABLE example(id INTEGER PRIMARY KEY, test JSONB)")
-            execute("INSERT INTO example(test) VALUES ('{\"test\": \"hello\"}')")
-            query<ExampleResponse>("SELECT * FROM example LIMIT 1;")
-                .singleNullable()
-        }
-
-        assertNotNull(res)
-        assertEquals("hello", res.test.test)
-    }
-
-    @Test
-    fun `kotlinx obj deserialization`() = runTest {
-        val ironSerializationInstance = Iron(
-            "jdbc:sqlite::memory:",
-            IronSettings(
-                serialization = SerializationAdapter.Kotlinx(Json)
-            )
-        ).connect()
-
-        @Serializable
-        data class EmbeddedJson(val test: String)
-        data class ExampleResponse(
-            @Column(json = true)
-            val test: EmbeddedJson
-        )
-
-        val res = ironSerializationInstance.transaction {
-            execute("CREATE TABLE example(id INTEGER PRIMARY KEY, test JSONB)")
-            execute("INSERT INTO example(test) VALUES ('{\"test\": \"hello\"}')")
-            query<ExampleResponse>("SELECT * FROM example LIMIT 1;")
-                .singleNullable()
-        }
-
-        assertNotNull(res)
-        assertEquals("hello", res.test.test)
     }
 }

--- a/src/test/kotlin/DeserializationTest.kt
+++ b/src/test/kotlin/DeserializationTest.kt
@@ -1,0 +1,92 @@
+import com.google.gson.Gson
+import gg.ingot.iron.Iron
+import gg.ingot.iron.IronSettings
+import gg.ingot.iron.annotations.Column
+import gg.ingot.iron.serialization.ColumnDeserializer
+import gg.ingot.iron.serialization.SerializationAdapter
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class DeserializationTest {
+    @Test
+    fun `gson obj deserialization`() = runTest {
+        val ironSerializationInstance = Iron(
+            "jdbc:sqlite::memory:",
+            IronSettings(
+                serialization = SerializationAdapter.Gson(Gson())
+            )
+        ).connect()
+
+        data class EmbeddedJson(val test: String)
+        data class ExampleResponse(
+            @Column(json = true)
+            val test: EmbeddedJson
+        )
+
+        val res = ironSerializationInstance.transaction {
+            execute("CREATE TABLE example(id INTEGER PRIMARY KEY, test JSONB)")
+            execute("INSERT INTO example(test) VALUES ('{\"test\": \"hello\"}')")
+            query<ExampleResponse>("SELECT * FROM example LIMIT 1;")
+                .singleNullable()
+        }
+
+        assertNotNull(res)
+        assertEquals("hello", res.test.test)
+    }
+
+    @Test
+    fun `kotlinx obj deserialization`() = runTest {
+        val ironSerializationInstance = Iron(
+            "jdbc:sqlite::memory:",
+            IronSettings(
+                serialization = SerializationAdapter.Kotlinx(Json)
+            )
+        ).connect()
+
+        @Serializable
+        data class EmbeddedJson(val test: String)
+        data class ExampleResponse(
+            @Column(json = true)
+            val test: EmbeddedJson
+        )
+
+        val res = ironSerializationInstance.transaction {
+            execute("CREATE TABLE example(id INTEGER PRIMARY KEY, test JSONB)")
+            execute("INSERT INTO example(test) VALUES ('{\"test\": \"hello\"}')")
+            query<ExampleResponse>("SELECT * FROM example LIMIT 1;")
+                .singleNullable()
+        }
+
+        assertNotNull(res)
+        assertEquals("hello", res.test.test)
+    }
+
+    data class CustomType(val str: String)
+    object CustomTypeDeserializer : ColumnDeserializer<String, CustomType> {
+        override fun deserialize(value: String): CustomType = CustomType(value)
+    }
+
+    @Test
+    fun `custom deserializer`() = runTest {
+        val connection = Iron("jdbc:sqlite::memory:").connect()
+
+        data class Response(
+            @Column(deserializer = CustomTypeDeserializer::class)
+            val example: CustomType
+        )
+
+        val res = connection.transaction {
+            execute("CREATE TABLE example(id INTEGER PRIMARY KEY, example TEXT)")
+            execute("INSERT INTO example(example) VALUES ('hello')")
+            query<Response>("SELECT * FROM example LIMIT 1;")
+                .singleNullable()
+        }
+
+        assertNotNull(res)
+        assertEquals("hello", res.example.str)
+    }
+}


### PR DESCRIPTION
Sometimes you may want to adapt a retrieved `Column` into another completely different type, for this you'll need to implement a `ColumnDeserializer` and mark the field on your model to be deserialized as such.

Here is an example of how to deserialize a retrieved field into a completely different type.
```kotlin
data class CustomType(
    val str: String
)

object CustomTypeColumnDeserializer : ColumnDeserializer<String, CustomType> {
    override fun deserialize(value: String): CustomType = CustomType(value)
}

data class ResponseModel(
    @Column(deserializer = CustomTypeColumnDeserializer::class)
    val example: CustomType
)

connection.query<ResponseModel>("SELECT example FROM test_table LIMIT 1;").single()
```
It integrates the exact same with all existing queries, you just need to add the deserializer to the column and provide the correct type alongside with it.