### PR TITLE
Utility Extensions for ResultSet

### DIFF
--- a/src/main/kotlin/gg/ingot/iron/sql/ResultSetExt.kt
+++ b/src/main/kotlin/gg/ingot/iron/sql/ResultSetExt.kt
@@ -83,6 +83,12 @@ inline fun <reified T> ResultSet.get(column: Int): T {
  * @return The value from the result set, or null if the value is null.
  */
 inline fun <reified T> ResultSet.getNullable(column: String): T? {
+    // for some reason throwing it in the when clause
+    // doesn't work?
+    if(Array::class.java.isAssignableFrom(T::class.java)) {
+        return getArray(column)?.array as? T
+    }
+
     return when (T::class) {
         Int::class -> getInt(column)
         Double::class -> getDouble(column)
@@ -107,5 +113,5 @@ inline fun <reified T> ResultSet.getNullable(column: String): T? {
  * @return The value from the result set.
  */
 inline fun <reified T> ResultSet.getNullable(column: Int): T? {
-    return getNullable(this.metaData.getColumnName(column))
+    return getNullable(metaData.getColumnName(column))
 }

--- a/src/main/kotlin/gg/ingot/iron/sql/ResultSetExt.kt
+++ b/src/main/kotlin/gg/ingot/iron/sql/ResultSetExt.kt
@@ -83,6 +83,11 @@ inline fun <reified T> ResultSet.get(column: Int): T {
  * @return The value from the result set, or null if the value is null.
  */
 inline fun <reified T> ResultSet.getNullable(column: String): T? {
+    // use array and convert to a collection from that if you need to
+    if(Collection::class.java.isAssignableFrom(T::class.java)) {
+        error("Use the Array type instead of a Collection")
+    }
+
     // for some reason throwing it in the when clause
     // doesn't work?
     if(Array::class.java.isAssignableFrom(T::class.java)) {

--- a/src/main/kotlin/gg/ingot/iron/sql/ResultSetExt.kt
+++ b/src/main/kotlin/gg/ingot/iron/sql/ResultSetExt.kt
@@ -1,0 +1,122 @@
+@file:Suppress("DuplicatedCode")
+
+package gg.ingot.iron.sql
+
+import java.sql.ResultSet
+
+/**
+ * Extension function to retrieve a single value from a result set.
+ * @return The value from the result set.
+ */
+inline fun <reified T> ResultSet.singleValue(): T {
+    return singleValueNullable<T>()
+        ?: error("No results in result set")
+}
+
+/**
+ * Extension function to retrieve a single value from a result set.
+ * @return The value from the result set or null if the value is null.
+ */
+inline fun <reified T> ResultSet.singleValueNullable(): T? {
+    check(metaData.columnCount == 1) { "Result set must have exactly one column" }
+    check(next()) { "No results in result set" }
+
+    val value = get<T>(1)
+
+    check(!next()) { "More than one result in result set" }
+
+    return value
+}
+
+/**
+ * Extension function to retrieve all values from a result set.
+ * @return A list of values from the result set.
+ */
+inline fun <reified T> ResultSet.allValues(): List<T> {
+    check(metaData.columnCount == 1) { "Result set must have exactly one column" }
+
+    return allValuesNullable<T>()
+        .mapNotNull { it }
+}
+
+/**
+ * Extension function to retrieve all values from a result set.
+ * @return A list of values from the result set.
+ */
+inline fun <reified T> ResultSet.allValuesNullable(): List<T?> {
+    check(metaData.columnCount == 1) { "Result set must have exactly one column" }
+
+    val list = mutableListOf<T?>()
+    while (next()) {
+        list.add(getNullable<T>(1))
+    }
+    return list
+}
+
+/**
+ * Extension function to retrieve a column from a result set
+ * and cast it to the desired type.
+ * @param column The column name to retrieve.
+ * @return The value from the result set.
+ */
+inline fun <reified T> ResultSet.get(column: String): T {
+    return getNullable<T>(column) ?: error("Value is null")
+}
+
+/**
+ * Extension function to retrieve a column from a result set
+ * and cast it to the desired type.
+ * @param column The column index to retrieve.
+ * @return The value from the result set.
+ */
+inline fun <reified T> ResultSet.get(column: Int): T {
+    return getNullable<T>(column) ?: error("Value is null")
+}
+
+/**
+ * Extension function to retrieve a column from a result set
+ * and cast it to the desired type.
+ * @param column The column name to retrieve.
+ * @return The value from the result set, or null if the value is null.
+ */
+inline fun <reified T> ResultSet.getNullable(column: String): T? {
+    return when (T::class) {
+        Int::class -> getInt(column)
+        Double::class -> getDouble(column)
+        Float::class -> getFloat(column)
+        Short::class -> getShort(column)
+        Long::class -> getLong(column)
+        Byte::class -> getByte(column)
+        ByteArray::class -> getBytes(column)
+        String::class -> getString(column)
+        java.sql.Date::class -> getDate(column)
+        java.sql.Time::class -> getTime(column)
+        java.sql.Timestamp::class -> getTimestamp(column)
+        java.net.URL::class -> getURL(column)
+        else -> error("Unsupported type ${T::class.simpleName}")
+    } as? T
+}
+
+/**
+ * Extension function to retrieve a column from a result set
+ * and cast it to the desired type.
+ * @param column The column index to retrieve.
+ * @return The value from the result set.
+ */
+inline fun <reified T> ResultSet.getNullable(column: Int): T? {
+    return when (T::class) {
+        Int::class -> getInt(column)
+        Double::class -> getDouble(column)
+        Float::class -> getFloat(column)
+        Short::class -> getShort(column)
+        Long::class -> getLong(column)
+        Byte::class -> getByte(column)
+        ByteArray::class -> getBytes(column)
+        String::class -> getString(column)
+        java.sql.Date::class -> getDate(column)
+        java.sql.Time::class -> getTime(column)
+        java.sql.Timestamp::class -> getTimestamp(column)
+        java.net.URL::class -> getURL(column)
+        else -> error("Unsupported type ${T::class.simpleName}")
+    } as? T
+}

--- a/src/main/kotlin/gg/ingot/iron/sql/ResultSetExt.kt
+++ b/src/main/kotlin/gg/ingot/iron/sql/ResultSetExt.kt
@@ -32,11 +32,14 @@ inline fun <reified T> ResultSet.singleValueNullable(): T? {
  * Extension function to retrieve all values from a result set.
  * @return A list of values from the result set.
  */
+@Suppress("UNCHECKED_CAST")
 inline fun <reified T> ResultSet.allValues(): List<T> {
-    check(metaData.columnCount == 1) { "Result set must have exactly one column" }
+    val values = allValuesNullable<T>()
+    check(!values.any { it == null }) { "Result set contains null values" }
 
-    return allValuesNullable<T>()
-        .mapNotNull { it }
+    // we've already checked there are no null values
+    // & i don't want to re-allocate a new ArrayList for this op - tech
+    return values as List<T>
 }
 
 /**

--- a/src/main/kotlin/gg/ingot/iron/sql/ResultSetExt.kt
+++ b/src/main/kotlin/gg/ingot/iron/sql/ResultSetExt.kt
@@ -107,19 +107,5 @@ inline fun <reified T> ResultSet.getNullable(column: String): T? {
  * @return The value from the result set.
  */
 inline fun <reified T> ResultSet.getNullable(column: Int): T? {
-    return when (T::class) {
-        Int::class -> getInt(column)
-        Double::class -> getDouble(column)
-        Float::class -> getFloat(column)
-        Short::class -> getShort(column)
-        Long::class -> getLong(column)
-        Byte::class -> getByte(column)
-        ByteArray::class -> getBytes(column)
-        String::class -> getString(column)
-        java.sql.Date::class -> getDate(column)
-        java.sql.Time::class -> getTime(column)
-        java.sql.Timestamp::class -> getTimestamp(column)
-        java.net.URL::class -> getURL(column)
-        else -> error("Unsupported type ${T::class.simpleName}")
-    } as? T
+    return getNullable(this.metaData.getColumnName(column))
 }

--- a/src/test/kotlin/DatabaseTest.kt
+++ b/src/test/kotlin/DatabaseTest.kt
@@ -4,6 +4,9 @@ import gg.ingot.iron.Iron
 import gg.ingot.iron.IronSettings
 import gg.ingot.iron.annotations.Column
 import gg.ingot.iron.serialization.SerializationAdapter
+import gg.ingot.iron.sql.allValues
+import gg.ingot.iron.sql.get
+import gg.ingot.iron.sql.singleValue
 import java.sql.SQLException
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -239,7 +242,7 @@ class DatabaseTest {
 
                 query("SELECT * FROM test LIMIT 1;")
                     .singleValue<String>()
-            }
+           }
         } catch(ex: Exception) {
             assert(ex is IllegalStateException)
         }
@@ -253,19 +256,6 @@ class DatabaseTest {
 
             query("SELECT name FROM test LIMIT 1;")
                 .get<String>("name")
-        }
-
-        assertEquals("test1", name)
-    }
-
-    @Test
-    fun `retrieve column value by column number`() = runTest {
-        val name = connection.transaction {
-            execute("CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)")
-            execute("INSERT INTO test(name) VALUES ('test1')")
-
-            query("SELECT name FROM test LIMIT 1;")
-                .get<String>(1)
         }
 
         assertEquals("test1", name)

--- a/src/test/kotlin/DatabaseTest.kt
+++ b/src/test/kotlin/DatabaseTest.kt
@@ -5,6 +5,7 @@ import gg.ingot.iron.IronSettings
 import gg.ingot.iron.annotations.Column
 import gg.ingot.iron.serialization.SerializationAdapter
 import gg.ingot.iron.sql.allValues
+import gg.ingot.iron.sql.get
 import gg.ingot.iron.sql.singleValue
 import java.sql.SQLException
 import kotlin.test.Test
@@ -245,5 +246,31 @@ class DatabaseTest {
         } catch(ex: Exception) {
             assert(ex is IllegalStateException)
         }
+    }
+
+    @Test
+    fun `retrieve column value by name`() = runTest {
+        val name = connection.transaction {
+            execute("CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)")
+            execute("INSERT INTO test(name) VALUES ('test1')")
+
+            query("SELECT name FROM test LIMIT 1;")
+                .get<String>("name")
+        }
+
+        assertEquals("test1", name)
+    }
+
+    @Test
+    fun `retrieve column value by column number`() = runTest {
+        val name = connection.transaction {
+            execute("CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)")
+            execute("INSERT INTO test(name) VALUES ('test1')")
+
+            query("SELECT name FROM test LIMIT 1;")
+                .get<String>(1)
+        }
+
+        assertEquals("test1", name)
     }
 }


### PR DESCRIPTION
Allows us to easily query exactly a single value from the ResultSet without needing to create an entirely new model to support that behavior.

Adds the following extensions to `ResultSet`,
`#singleValue` - Retrieve first column of ResultSet as provided type.
`#singleValueNullable` - Retrieve first column of ResultSet as provided type, can be null.
`#allValues` - Map first column of ResultSet as provided type, will throw if any element is null.
`#allValuesNullable` - Map first column of ResultSet as provided type.
`#get` - Retrieve column as provided type. 