### PR TITLE
Enum Column Deserializer

### DIFF
--- a/src/main/kotlin/gg/ingot/iron/serialization/ColumnDeserializer.kt
+++ b/src/main/kotlin/gg/ingot/iron/serialization/ColumnDeserializer.kt
@@ -16,6 +16,21 @@ interface ColumnDeserializer <From, To> {
     fun deserialize(value: From): To
 }
 
+/**
+ * Deserialize an enum from a string, will automatically retrieve the
+ * enum type from the parameter field.
+ * @param clazz The class of the enum to deserialize.
+ *  @author DebitCardz
+ *  @since 1.0.3
+ */
+internal class EnumColumnDeserializer(
+    private val clazz: Class<out Enum<*>>
+) : ColumnDeserializer<String, Enum<*>> {
+    override fun deserialize(value: String): Enum<*> {
+        return java.lang.Enum.valueOf(clazz, value)
+    }
+}
+
 // Internally used to denote that a column should not be deserialized.
 internal object EmptyDeserializer : ColumnDeserializer<Nothing, Nothing> {
     override fun deserialize(value: Nothing): Nothing = error("This deserializer should not be used")

--- a/src/main/kotlin/gg/ingot/iron/sql/ResultSetExt.kt
+++ b/src/main/kotlin/gg/ingot/iron/sql/ResultSetExt.kt
@@ -94,6 +94,15 @@ inline fun <reified T> ResultSet.getNullable(column: String): T? {
         return getArray(column)?.array as? T
     }
 
+    // enum checks
+    if(Enum::class.java.isAssignableFrom(T::class.java)) {
+        val value = getString(column)
+            ?: return null
+
+        val clazz = T::class.java as Class<out Enum<*>>
+        return java.lang.Enum.valueOf(clazz, value) as? T
+    }
+
     return when (T::class) {
         Int::class -> getInt(column)
         Double::class -> getDouble(column)

--- a/src/test/kotlin/DeserializationTest.kt
+++ b/src/test/kotlin/DeserializationTest.kt
@@ -3,11 +3,12 @@ import gg.ingot.iron.Iron
 import gg.ingot.iron.IronSettings
 import gg.ingot.iron.annotations.Column
 import gg.ingot.iron.serialization.ColumnDeserializer
-import gg.ingot.iron.serialization.EnumColumnDeserializer
 import gg.ingot.iron.serialization.SerializationAdapter
+import gg.ingot.iron.sql.singleValue
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertTrue
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -124,5 +125,20 @@ class DeserializationTest {
         } catch(ex: Exception) {
             assert(ex is IllegalArgumentException)
         }
+    }
+
+    @Test
+    fun `enum deserializer single`() = runTest {
+        val connection = Iron("jdbc:sqlite::memory:").connect()
+
+        val enumValue = connection.transaction {
+            execute("CREATE TABLE example(id INTEGER PRIMARY KEY, example TEXT)")
+            execute("INSERT INTO example(example) VALUES ('EXAMPLE')")
+
+            query("SELECT example FROM example LIMIT 1;")
+                .singleValue<TestEnum>()
+        }
+
+        assertEquals(enumValue, TestEnum.EXAMPLE)
     }
 }

--- a/src/test/kotlin/DeserializationTest.kt
+++ b/src/test/kotlin/DeserializationTest.kt
@@ -103,7 +103,7 @@ class DeserializationTest {
         val res = connection.transaction {
             execute("CREATE TABLE example(id INTEGER PRIMARY KEY, example TEXT)")
             execute("INSERT INTO example(example) VALUES ('EXAMPLE')")
-            query<Response>("SELECT * FROM example LIMIT 1;")
+            queryMapped<Response>("SELECT * FROM example LIMIT 1;")
                 .singleNullable()
         }
 
@@ -120,7 +120,7 @@ class DeserializationTest {
             connection.transaction {
                 execute("CREATE TABLE example(id INTEGER PRIMARY KEY, example TEXT)")
                 execute("INSERT INTO example(example) VALUES ('INVALID')")
-                query<Response>("SELECT * FROM example LIMIT 1;")
+                queryMapped<Response>("SELECT * FROM example LIMIT 1;")
                     .singleNullable()
             }
         } catch(ex: Exception) {


### PR DESCRIPTION
When passing a Enum into a Model it'll automatically attempt to deserialize the string as the enum.
```kt
enum class Test { EXAMPLE, EXAMPLE_2 };
data class Model(val test: Test)

val mapped = conn.queryMapped<Model>("SELECT test FROM example LIMIT 1;")
     .single()
 println(mapped.test.name)
 ```